### PR TITLE
tokenを使用しないで、パスワードによるローカル実行環境の作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,42 @@
-.Trash-0/
-
-# Jupyter Notebook チェックポイントファイル
-.ipynb_checkpoints/
+# Jupyter Notebook
+.ipynb_checkpoints
 */.ipynb_checkpoints/*
 
-# 一時ファイル
-*.tmp
-*.swp
-*.swo
+# IPython
+profile_default/
+ipython_config.py
 
-# マウントしたディレクトリ内の無関係なファイル
-src/.ipynb_checkpoints/
-src/*/.ipynb_checkpoints/*
-src/*.tmp
-src/*.swp
-src/*.swo
+# Jupyter Notebook をビルドする際に生成されるファイル
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Jupyter Notebook のカスタムランチャーを使用する際に生成されるファイル
+.jupyter/jupyter_notebook_config.json
+
+# データファイル、CSVファイル、モデルファイルなど（必要に応じて）
+*.csv
+*.pkl
+*.h5
+*.model
+
+# 環境固有のファイル（必要に応じて）
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# ログファイル（必要に応じて）
+*.log
+
+# OS固有のファイル（必要に応じて）
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -2,33 +2,24 @@
 
 ## Build
 ```shell
-docker build -t jupyter-notebook .
-```
-※`jupyter-notebook`はコンテナ名
-```shell
-Successfully built (IMAGE ID) //この文字が出力されたらOK
+docker compose build
 ```
 
 ## Run
 ```shell
-docker run -p 8888:8888 -v ${PWD}:/project jupyter-notebook
+docker compose up -d
 ```
 
 # ローカルでの実行方法（カーネルの設定）
 1. Dockerを起動する
-    `docker run -p 8888:8888 -v ${PWD}:/project jupyter-notebook`
-
-2. 実行後にターミナルに出現するtokenを取得する
     ```shell
-    To access the server, open this file in a browser:
-        file:///root/.local/share/jupyter/runtime/jpserver-1-open.html
-    Or copy and paste one of these URLs:
-        http://57dcf183c91b:8888/tree?token={token}
-        http://127.0.0.1:8888/tree?token={token}
+    docker compose up -d
     ```
 
-3. VScodeでカーネルの選択を「別のカーネルを選択」する
+2. VScodeでカーネルの選択を「別のカーネルを選択」する
 
-4. `http://127.0.0.1:8888/tree?token={token}`をURLに入力する
+3. `http://127.0.0.1:8888/`をURLに入力する
 
-5. tokenのみを入力する
+4. パスワードを入力する
+
+5. pythonカーネルを選択する

--- a/README.md
+++ b/README.md
@@ -1,16 +1,30 @@
 # docker-jupyter
 
-## Build
+## コンテナの起動
 ```shell
-docker compose build
+docker compose build # build
+docker compose up -d # run
 ```
+# 初めて環境構築する場合の手順
 
-## Run
-```shell
-docker compose up -d
-```
+## (i). パスワードの設定
+1. Google Colabを開く
 
-# ローカルでの実行方法（カーネルの設定）
+2. 任意のパスワードを決める
+
+3. 以下のコードでハッシュ化を行う
+    ```python
+    from notebook.auth import passwd
+    passwd()
+    ```
+    <img width="420" alt="パスワードハッシュ化入力" src="https://github.com/ShotaArima/docker-jupyter/assets/130956497/36046f6c-d36a-4c25-a5b1-bd2d5b37d7ce">
+
+    このコードを実行後、プロンプト下部にパスワード入力欄があるので入力する
+    <img width="420" alt="パスワードハッシュ化確認" src="https://github.com/ShotaArima/docker-jupyter/assets/130956497/4ddb823c-5302-453d-9682-6a4d7f6a8ff4">
+
+    
+
+## (ii). ローカルでの実行方法（カーネルの設定）
 1. Dockerを起動する
     ```shell
     docker compose up -d

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  jupyter:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./src:/src
+    ports:
+      - "8888:8888"
+    environment:
+      - JUPYTER_ENEBLE_LAB=yes
+    command: ["conda", "run", "-n", "pymc_env", "jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--allow-root", "--no-browser", "--NotebookApp.password={$hashedpass}"]

--- a/dockerfile
+++ b/dockerfile
@@ -8,3 +8,4 @@ WORKDIR /project
 RUN apt-get update && apt-get install -y nano
 
 CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root", "--no-browser"]
+# ハッシュ化されたパスワードの設定

--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,28 @@
-FROM python:3.9
+# ベースイメージの指定
+FROM continuumio/miniconda3:latest
 
-RUN pip install jupyter
+# wgetとunzipをインストール
+RUN apt-get update && apt-get install -y wget unzip
 
-RUN mkdir /project
-WORKDIR /project
+# environment.ymlをコピーして環境を作成
+COPY environment.yml /tmp/
+RUN conda env create -f /tmp/environment.yml
 
-RUN apt-get update && apt-get install -y nano
+# デフォルトでAnaconda環境をアクティブ化
+SHELL ["/bin/bash", "-c"]
 
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--allow-root", "--no-browser"]
-# ハッシュ化されたパスワードの設定
+# 作業ディレクトリを設定
+WORKDIR /src/
+
+# matplotlibの設定ファイルをコピー
+COPY matplotlibrc /src/.config/matplotlib/
+
+# ポートの公開
+EXPOSE 8888
+
+# 日本語フォントの設定
+RUN wget -O font.zip "https://moji.or.jp/wp-content/ipafont/IPAexfont/ipaexg00401.zip"
+RUN unzip font.zip
+RUN cp ipaexg00401/ipaexg.ttf /opt/conda/envs/pymc_env/lib/python3.11/site-packages/matplotlib/mpl-data/fonts/ttf/ipaexg.ttf
+RUN echo "font.family : IPAexGothic" >>  /opt/conda/envs/pymc_env/lib/python3.11/site-packages/matplotlib/mpl-data/matplotlibrc
+# RUN rm -r ./.cache

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,11 @@
+
+name: pymc_env
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - numpy
+  - pandas
+  - matplotlib
+  - scipy
+  - jupyter

--- a/src/tmp.ipynb
+++ b/src/tmp.ipynb
@@ -14,9 +14,7 @@
      ]
     }
    ],
-   "source": [
-    "print(\"Hello World!\")"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -32,12 +30,7 @@
      ]
     }
    ],
-   "source": [
-    "a=1\n",
-    "b=2\n",
-    "c=a+b\n",
-    "print(c)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
close:#1

## What?（変更の概要・何を変更したのか）

- tokenでのローカル環境での実行接続ではなく、パスワードによる実行を可能にする

## Why?（なぜ変更するのか）

- tokenをコピーして、貼り付けての作業がめんどくさい

## How?（どう変更するのか）

- Dockerfileの`CMD`行にハッシュ化されたパスワードを仕込み、コンテナ起動時に指定のサイトでパスワードを入力し、接続を行う

## Checklist

- [x] ブランチの作成
- [x] パスワードの生成
- [x] Dockerfileの変更
- [ ] コンテナのbuild
- [ ] コンテナ起動
- [ ] 検証